### PR TITLE
impl SingleThreadEventLoop prioritize scheduled tasks by delay

### DIFF
--- a/core/src/main/java/io/el/concurrent/ScheduledTask.java
+++ b/core/src/main/java/io/el/concurrent/ScheduledTask.java
@@ -11,9 +11,9 @@ public class ScheduledTask<V> extends DefaultTask<V> implements Runnable, Priori
     return deadlineNanos < 0 ? Long.MAX_VALUE : deadlineNanos;
   }
 
-  final private long deadlineNanos;
+  private final long deadlineNanos;
 
-  private Runnable task;
+  private final Runnable task;
 
   private int queueIndex = INDEX_NOT_IN_QUEUE;
   private long id;

--- a/core/src/main/java/io/el/concurrent/ScheduledTask.java
+++ b/core/src/main/java/io/el/concurrent/ScheduledTask.java
@@ -36,16 +36,6 @@ public class ScheduledTask<V> extends DefaultTask<V> implements Runnable, Priori
   }
 
   @Override
-  public int priority() {
-    return queueIndex;
-  }
-
-  @Override
-  public void prioritize(int i) {
-
-  }
-
-  @Override
   public int index() {
     return queueIndex;
   }

--- a/core/src/main/java/io/el/concurrent/SingleThreadEventLoop.java
+++ b/core/src/main/java/io/el/concurrent/SingleThreadEventLoop.java
@@ -7,8 +7,10 @@ import io.el.internal.DefaultPriorityQueue;
 import io.el.internal.ObjectUtil;
 import io.el.internal.PriorityQueue;
 import io.el.internal.Time;
+import java.util.Comparator;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Delayed;
 import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.RejectedExecutionException;
@@ -19,6 +21,9 @@ public abstract class SingleThreadEventLoop extends AbstractEventLoop {
   private static final int INITIAL_QUEUE_CAPACITY = 16;
   private static final AtomicReferenceFieldUpdater<SingleThreadEventLoop, State> stateUpdater =
       AtomicReferenceFieldUpdater.newUpdater(SingleThreadEventLoop.class, State.class, "state");
+  private static final Comparator<ScheduledTask<?>> SCHEDULED_FUTURE_TASK_COMPARATOR =
+      ScheduledTask::compareTo;
+
   private final Executor executor;
   private volatile Thread thread;
   private volatile State state = State.NOT_STARTED;
@@ -31,7 +36,9 @@ public abstract class SingleThreadEventLoop extends AbstractEventLoop {
   public SingleThreadEventLoop(Executor executor) {
     this.executor = executor;
     this.taskQueue = new LinkedBlockingDeque<>(INITIAL_QUEUE_CAPACITY);
-    this.scheduledTaskQueue = new DefaultPriorityQueue<>(INITIAL_QUEUE_CAPACITY);
+    this.scheduledTaskQueue = new DefaultPriorityQueue<>(
+        INITIAL_QUEUE_CAPACITY,
+        SCHEDULED_FUTURE_TASK_COMPARATOR);
   }
 
   @Override

--- a/core/src/main/java/io/el/internal/DefaultPriorityQueue.java
+++ b/core/src/main/java/io/el/internal/DefaultPriorityQueue.java
@@ -4,6 +4,7 @@ import static io.el.internal.PriorityQueueNode.INDEX_NOT_IN_QUEUE;
 
 import java.util.AbstractQueue;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -11,12 +12,16 @@ public class DefaultPriorityQueue<T extends PriorityQueueNode> extends AbstractQ
     PriorityQueue<T> {
 
   private static final PriorityQueueNode[] EMPTY_ARRAY = new PriorityQueueNode[0];
+
+  private final Comparator<T> comparator;
+
   private T[] items;
   private int size;
 
   @SuppressWarnings("unchecked")
-  public DefaultPriorityQueue(int initialSize) {
+  public DefaultPriorityQueue(int initialSize, Comparator<T> comparator) {
     this.items = (T[]) (initialSize != 0 ? new PriorityQueueNode[initialSize] : EMPTY_ARRAY);
+    this.comparator = comparator;
   }
 
   @Override
@@ -46,7 +51,7 @@ public class DefaultPriorityQueue<T extends PriorityQueueNode> extends AbstractQ
     items[size] = node;
 
     int current = size;
-    while (node.priority() < parent(current).priority()) {
+    while (comparator.compare(node, parent(current)) < 0) {
       int parentIndex = parent(current).index();
       swap(current, parentIndex);
       current = parentIndex;
@@ -157,7 +162,7 @@ public class DefaultPriorityQueue<T extends PriorityQueueNode> extends AbstractQ
       bubbleDown(0);
       return;
     }
-    if (node.priority() < parent(node.index()).priority()) {
+    if (comparator.compare(node, parent(node.index())) < 0) {
       bubbleUp(node);
       return;
     }
@@ -182,10 +187,9 @@ public class DefaultPriorityQueue<T extends PriorityQueueNode> extends AbstractQ
 
     T left = leftChild(node);
     T right = rightChild(node);
-    int priority = node.priority();
 
     if (left == null) {
-      if (priority <= right.priority()) {
+      if (comparator.compare(node, right) <= 0) {
         return;
       }
       swap(node.index(), right.index());
@@ -194,7 +198,7 @@ public class DefaultPriorityQueue<T extends PriorityQueueNode> extends AbstractQ
     }
 
     if (right == null) {
-      if (priority <= left.priority()) {
+      if (comparator.compare(node, left) <= 0) {
         return;
       }
       swap(node.index(), left.index());
@@ -202,10 +206,10 @@ public class DefaultPriorityQueue<T extends PriorityQueueNode> extends AbstractQ
       return;
     }
 
-    if (priority <= left.priority() && priority <= right.priority()) {
+    if (comparator.compare(node, left) <= 0 && comparator.compare(node, right) <= 0) {
       return;
     }
-    if (left.priority() < right.priority()) {
+    if (comparator.compare(left, right) < 0) {
       swap(node.index(), left.index());
       bubbleDown(node.index());
       return;
@@ -216,7 +220,7 @@ public class DefaultPriorityQueue<T extends PriorityQueueNode> extends AbstractQ
 
   private void bubbleUp(T node) {
     int current = node.index();
-    while (node.priority() < parent(current).priority()) {
+    while (comparator.compare(node, parent(current)) < 0) {
       int parentIndex = parent(current).index();
       swap(current, parentIndex);
       current = parentIndex;

--- a/core/src/main/java/io/el/internal/PriorityQueueNode.java
+++ b/core/src/main/java/io/el/internal/PriorityQueueNode.java
@@ -5,10 +5,6 @@ public interface PriorityQueueNode {
   int PRIORITY_NOT_IN_QUEUE = -1;
   int INDEX_NOT_IN_QUEUE = -1;
 
-  int priority();
-
-  void prioritize(int i);
-
   int index();
 
   void index(int i);

--- a/core/src/test/java/io/el/internal/DefaultPriorityQueueTest.java
+++ b/core/src/test/java/io/el/internal/DefaultPriorityQueueTest.java
@@ -281,16 +281,6 @@ public class DefaultPriorityQueueTest {
         }
 
         @Override
-        public int priority() {
-            return value;
-        }
-
-        @Override
-        public void prioritize(int i) {
-            value = i;
-        }
-
-        @Override
         public int index() {
             return index;
         }

--- a/core/src/test/java/io/el/internal/DefaultPriorityQueueTest.java
+++ b/core/src/test/java/io/el/internal/DefaultPriorityQueueTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class DefaultPriorityQueueTest {
     @Test
     public void testPoll() {
-        PriorityQueue<TestElement> queue = new DefaultPriorityQueue<TestElement>(0);
+        PriorityQueue<TestElement> queue = new DefaultPriorityQueue<TestElement>(0, new TestElementComparator());
         assertEmptyQueue(queue);
 
         TestElement a = new TestElement(5);
@@ -62,7 +62,7 @@ public class DefaultPriorityQueueTest {
 
     @Test
     public void testClear() {
-        PriorityQueue<TestElement> queue = new DefaultPriorityQueue<TestElement>(0);
+        PriorityQueue<TestElement> queue = new DefaultPriorityQueue<TestElement>(0, new TestElementComparator());
         assertEmptyQueue(queue);
 
         TestElement a = new TestElement(5);
@@ -103,7 +103,7 @@ public class DefaultPriorityQueueTest {
     }
 
     private static void testRemoval(boolean typed) {
-        PriorityQueue<TestElement> queue = new DefaultPriorityQueue<TestElement>(4);
+        PriorityQueue<TestElement> queue = new DefaultPriorityQueue<TestElement>(4, new TestElementComparator());
         assertEmptyQueue(queue);
 
         TestElement a = new TestElement(5);
@@ -152,7 +152,7 @@ public class DefaultPriorityQueueTest {
 
     @Test
     public void testChangePriority() {
-        PriorityQueue<TestElement> queue = new DefaultPriorityQueue<TestElement>(0);
+        PriorityQueue<TestElement> queue = new DefaultPriorityQueue<TestElement>(0, new TestElementComparator());
         assertEmptyQueue(queue);
         TestElement a = new TestElement(10);
         TestElement b = new TestElement(20);
@@ -201,7 +201,7 @@ public class DefaultPriorityQueueTest {
 
     @Test
     public void testRemove() {
-        PriorityQueue<TestElement> queue = new DefaultPriorityQueue<TestElement>(0);
+        PriorityQueue<TestElement> queue = new DefaultPriorityQueue<TestElement>(0, new TestElementComparator());
         assertEmptyQueue(queue);
 
         TestElement a = new TestElement(5);


### PR DESCRIPTION
Before this code, `SingleThreadEventLoop` cannot prioritize multiple tasks by its deadline. But now `SingleThreadEventLoop` can prioritize tasks by their deadline. If one task has the closest deadline its priority becomes high.

Resolved #8 