### PR TITLE
feat: add DefaultChannelHandlerContext

### DIFF
--- a/transport/src/main/java/io/el/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/el/channel/AbstractChannelHandlerContext.java
@@ -6,6 +6,7 @@ import static io.el.channel.ChannelHandlerFlag.flag;
 
 import io.el.concurrent.EventLoop;
 import io.el.internal.ObjectUtil;
+import java.net.SocketAddress;
 
 abstract public class AbstractChannelHandlerContext implements ChannelHandlerContext {
 
@@ -108,5 +109,24 @@ abstract public class AbstractChannelHandlerContext implements ChannelHandlerCon
       ctx = ctx.next;
     } while (ctx.executionFlag != FLAG_INBOUND);
     return ctx;
+  }
+
+  @Override
+  public ChannelPromise bind(SocketAddress localAddress) {
+    // TODO: implement me
+    return null;
+  }
+
+  @Override
+  public ChannelPromise bind(SocketAddress localAddress, ChannelPromise promise) {
+    // TODO: implement me
+    return null;
+  }
+
+  @Override
+  public ChannelPromise connect(SocketAddress remoteAddress, SocketAddress localAddress,
+      // TODO: implement me
+      ChannelPromise promise) {
+    return null;
   }
 }

--- a/transport/src/main/java/io/el/channel/DefaultChannelHandlerContext.java
+++ b/transport/src/main/java/io/el/channel/DefaultChannelHandlerContext.java
@@ -1,0 +1,19 @@
+package io.el.channel;
+
+import io.el.concurrent.EventLoop;
+
+public final class DefaultChannelHandlerContext extends AbstractChannelHandlerContext {
+
+  private final ChannelHandler handler;
+
+  DefaultChannelHandlerContext(String name, ChannelPipeline pipeline,
+      EventLoop eventLoop, ChannelHandler handler) {
+    super(name, pipeline, eventLoop, handler.getClass());
+    this.handler = handler;
+  }
+
+  @Override
+  public ChannelHandler handler() {
+    return handler;
+  }
+}


### PR DESCRIPTION
close #48 

## Description

implements `DefaultChannelHandlerContext` which will be used in `DefaultChannelPipeline`

It is so simple that I think we don't test cases. Methods except `handler()` will be implemented in `AbstractChannelHandlerContext`